### PR TITLE
dodanie || oraz &&

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -144,11 +144,13 @@ void	parser_double_redirect_output(t_token **head, char **argv);
 char 	*redirect_double_output_helper(char **argv);
 void	parser_double_redirect_input(t_token **head, char **argv);
 char 	*redirect_double_input_helper(char **argv);
-void	parser_cd(t_token **head, char **args);
+void	parser_cd(t_token **head, char **args, int i);
 void	parser_export(t_token **head, char **args);
 int		is_valid_varname(const char *str);
 void	add_token(t_token **head, char *key, char *value);
 void    parser_unset(t_token **token, char **args);
 void    parser_env(t_token **token, char **args);
+void    parser_or(t_token **head);
+void    parser_and(t_token **head);
 
 #endif

--- a/sources/minishell.c
+++ b/sources/minishell.c
@@ -7,6 +7,16 @@ void	minishell_loop_helper(t_minishell *shell, char **args, t_token **token)
 		add_history(shell->line); // obsluga historii, poruszania sie strzalkami
 		args = ft_split(shell->line, ' '); // dzielenie linii na argumenty
 		parser(args, token);
+		t_token *tmp;
+		tmp = *token;
+		while (tmp)
+   	 	{
+        	if (tmp->type && strcmp(tmp->type, "cd") == 0)
+        	{
+            	printf("Wartość cd: %s\n", tmp->value);
+    		}
+        	tmp = tmp->next;
+    	}
 		if (!args)
 		{
 			free(shell->line);

--- a/sources/parser/parser.c
+++ b/sources/parser/parser.c
@@ -11,10 +11,16 @@ int count_echo_len(char **argv, int i)
 
 char *build_echo_value(char **argv)
 {
-    int i = (argv[1] && ft_strcmp(argv[1], "-n") == 0) ? 2 : 1;
-    int len = count_echo_len(argv, i);
-    char *result = malloc(len + 1);
+    int i;
+    int len;
+    char *result;
 
+    if (argv[1] && ft_strcmp(argv[1], "-n") == 0)
+        i = 2;
+    else
+        i = 1;
+    len = count_echo_len(argv, i);
+    result = malloc(len + 1);
     if (!result)
         return NULL;
 
@@ -86,22 +92,18 @@ void    parser(char **args, t_token **token)
     i = 0;
     while(args[i] != NULL)
     {
-        if (ft_strncmp(args[i], "pwd", 3) == 0)
+        if (ft_strcmp(args[i], "pwd") == 0)
             parser_pwd(token);
-        else if (ft_strncmp(args[i], "echo", 4) == 0)
+        else if (ft_strcmp(args[i], "echo") == 0)
             parser_echo(token, args);
-        else if (ft_strncmp(args[i], "|", 1) == 0)
-            parser_pipe(token);
-        else if (ft_strncmp(args[i], ">", 1) == 0)
-            parser_redirect_output(token, args);
-        else if (ft_strncmp(args[i], "<", 1) == 0)
-            parser_redirect_input(token, args);
-        else if (ft_strncmp(args[i], ">>", 1) == 0)
-            parser_double_redirect_output(token, args);
-        else if (ft_strncmp(args[i], "<<", 1) == 0)
-            parser_double_redirect_input(token, args);
-        else if (ft_strncmp(args[i], "cd", 1) == 0)
-            parser_cd(token, args);
+        else if (ft_strcmp(args[i], "export") == 0)
+		    parser_export(token, args);
+	    else if (ft_strcmp(args[i], "unset") == 0)
+		    parser_unset(token, args);
+	    else if (ft_strcmp(args[i], "env") == 0)
+		    parser_env(token, args);
+        else if (ft_strcmp(args[i], "cd") == 0)
+            parser_cd(token, args, i);
         else
             parser_helper(token, args, &i);
         i++;

--- a/sources/parser/parser4.c
+++ b/sources/parser/parser4.c
@@ -82,7 +82,7 @@ void	parser_export(t_token **head, char **args)
 	}
 }
 
-void	parser_cd(t_token **head, char **args)
+void	parser_cd(t_token **head, char **args, int i)
 {
 	t_token *new_token;
 	t_token *temp;
@@ -91,8 +91,8 @@ void	parser_cd(t_token **head, char **args)
 	if (!new_token)
 		return ;
 	new_token->type = "cd";
-    if(args[1])
-	    new_token->value = args[1];
+    if(args[i + 1])
+	    new_token->value = args[i + 1];
     else
     {
         new_token->value = NULL;

--- a/sources/parser/parser5.c
+++ b/sources/parser/parser5.c
@@ -1,5 +1,45 @@
 #include "../../includes/minishell.h"
 
+void    parser_and(t_token **head)
+{
+    t_token *new_token = malloc(sizeof(t_token));
+    t_token *temp;
+    if (!new_token)
+        return ;
+    new_token->type = "&&";
+    new_token->value = NULL;
+    new_token->next = NULL;
+    if (*head == NULL)
+        *head = new_token;
+    else
+    {
+        temp = *head;
+        while(temp->next)
+            temp = temp->next;
+        temp->next = new_token;
+    }
+}
+
+void    parser_or(t_token **head)
+{
+    t_token *new_token = malloc(sizeof(t_token));
+    t_token *temp;
+    if (!new_token)
+        return ;
+    new_token->type = "||";
+    new_token->value = NULL;
+    new_token->next = NULL;
+    if (*head == NULL)
+        *head = new_token;
+    else
+    {
+        temp = *head;
+        while(temp->next)
+            temp = temp->next;
+        temp->next = new_token;
+    }
+}
+
 void    parser_env(t_token **token, char **args)
 {
     if (args[1])

--- a/sources/utils/utils.c
+++ b/sources/utils/utils.c
@@ -28,13 +28,20 @@ void	init_token(t_token *token)
 
 void	parser_helper(t_token **token, char **args, int *i)
 {
-	if (ft_strncmp(args[*i], "export", 6) == 0)
-		parser_export(token, args);
-	else if (ft_strncmp(args[*i], "unset", 5) == 0)
-		parser_unset(token, args);
-	else if (ft_strncmp(args[*i], "env", 3) == 0)
-		parser_env(token, args);
-	
+	if (ft_strcmp(args[*i], "|") == 0)
+            parser_pipe(token);
+    else if (ft_strcmp(args[*i], ">") == 0)
+            parser_redirect_output(token, args);
+    else if (ft_strcmp(args[*i], "<") == 0)
+            parser_redirect_input(token, args);
+    else if (ft_strcmp(args[*i], ">>") == 0)
+            parser_double_redirect_output(token, args);
+    else if (ft_strcmp(args[*i], "<<") == 0)
+			parser_double_redirect_input(token, args);
+	else if (ft_strcmp(args[*i], "||") == 0)
+			parser_or(token);
+	else if (ft_strcmp(args[*i], "&&") == 0)
+			parser_and(token);
 }
 size_t	ft_strcpy(char *dst, const char *src)
 {

--- a/sources/utils/utils_b.c
+++ b/sources/utils/utils_b.c
@@ -4,5 +4,6 @@ int is_redirect_or_pipe(char *arg)
 {
     return (!ft_strcmp(arg, ">") || !ft_strcmp(arg, "<") ||
             !ft_strcmp(arg, ">>") || !ft_strcmp(arg, "<<") ||
-            !ft_strcmp(arg, "|"));
+            !ft_strcmp(arg, "|") || !ft_strcmp(arg, "&&") ||
+            !ft_strcmp(arg, "||"));
 }


### PR DESCRIPTION
Wszystkie komendy parsowane są na zasadzie typ i argument jedynie ||, && oraz pwd są parsowane bez żadnego argumentu tzn. mają tylko type. Wszystkie >>, <<, >, <, mają odpowiedni type oraz argument, którym jest jeden argument tzn. jeden ciąg znaków jak np. file.txt. cd powinno parsowac argumenty do napotkania końca ciągu znaków lub do napotkania <, >, <<, >>, |, ||, &&. Dalej nie rozwiązałem problemu echo "abc" - tzn. "". 