### PR TITLE
Poprawka do Issue #4 (cd o dwa katalogi)

### DIFF
--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -62,11 +62,7 @@ int	ft_cd(char **args) {
 		perror("cd() error");
 		return 1;
 	}
-	else
-	{
-		chdir(path);
-		return 0;
-	}
+	return 0;
 }
 
 void	ft_builtins(t_minishell *shell, char **args)


### PR DESCRIPTION
Poprawiony błąd z Issue komenda "cd .." wraca o dwa katalogi do góry, zamiast o jeden #4