### PR TITLE
Tomek/poprawki_env_export_unset

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -80,7 +80,8 @@ int		ft_echo(char **args);
 void	ft_exit(t_minishell *shell);
 void	ft_pwd(void);
 int		ft_env(t_env *env);
-int		ft_unset(t_env **env_list, char *key);
+int		ft_unset(t_env **env_list, char **args);
+int		ft_export(t_minishell *shell, char **args);
 char	*strip_quotes(const char *str);
 
 //redirections
@@ -101,6 +102,7 @@ int		is_builtin(char *cmd);
 //utils_t_2
 char	**conv_env_to_array(t_env *env); // konwersja listy zmiennych srodowiskowych na tablice
 char	**tokens_to_args(t_token *token); // konwersja listy tokenow na tablice argumentow
+int		is_valid_var_or_assign(const char *str);
 
 
 //utils
@@ -108,7 +110,7 @@ void	init_token(t_token **token);
 size_t	ft_strcpy(char *dst, const char *src);
 char	*ft_strcat(char *dst, const char *src);
 void	parser_helper(t_token **token, char **args, int *i);
-int is_redirect_or_pipe(char *arg);
+int		is_redirect_or_pipe(char *arg);
 
 //clean-up
 void	free_args(char **args);   // zwalnia pamiec po tablicy argumentow

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -152,7 +152,7 @@ void	parser_export(t_token **head, char **args);
 int		is_valid_varname(const char *str);
 void	add_token(t_token **head, char *key, char *value);
 void	parser_unset(t_token **token, char **args);
-void	parser_env(t_token **token, char **args);
+void	parser_env(t_token **token);
 void	parser_or(t_token **head);
 void	parser_and(t_token **head);
 void	parser_exit(t_token **head);

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -70,8 +70,7 @@ void	ft_builtins(t_minishell *shell, char **args)
 		return;
 	if (ft_strcmp(args[0], "pwd") == 0)
 		ft_pwd();
-	else if (ft_strcmp(args[0], "exit") == 0)
-	{
+	else if (ft_strcmp(args[0], "exit") == 0){
 		ft_exit(shell);
 		shell->running = 0; // ustawienie flagi do zakonczenia petli
 	}
@@ -82,9 +81,9 @@ void	ft_builtins(t_minishell *shell, char **args)
 	else if (ft_strcmp(args[0], "env") == 0)
 		shell->exit_status = ft_env(shell->env_list);
 	else if (ft_strcmp(args[0], "export") == 0)
-		shell->exit_status = add_env(&(shell->env_list), args[1], args[2]); // pass key and value
+		shell->exit_status = ft_export(shell, args);
 	else if (ft_strcmp(args[0], "unset") == 0)
-		shell->exit_status = ft_unset(&(shell->env_list), args[1]); // pass key
+		shell->exit_status = ft_unset(&(shell->env_list), args); // pass args
 	else
 	{
 		fprintf(stderr, "minishell: %s: command not found\n", args[0]);

--- a/sources/minishell.c
+++ b/sources/minishell.c
@@ -52,7 +52,7 @@ void	minishell_loop_helper(t_minishell *shell, char **args, t_token **token)
 
 void	minishell_loop(t_minishell *shell, char **args, t_token **token)
 {
-	while(1) // glowna petla
+	while(shell->running) // glowna petla
 	{
 		shell->line = readline("minishell$ "); // wyswietlanie i czytanie prompta
 		if(shell->line == NULL) // obsluga ctrl+d, ctrl+d zwraca NULL z readline

--- a/sources/parser/parser.c
+++ b/sources/parser/parser.c
@@ -122,7 +122,7 @@ void    parser(char **args, t_token **token)
 	    else if (ft_strcmp(args[i], "unset") == 0)
 		    parser_unset(token, args);
 	    else if (ft_strcmp(args[i], "env") == 0)
-		    parser_env(token, args);
+		    parser_env(token);
         else if (ft_strcmp(args[i], "cd") == 0){
             parser_cd(token, args, i);
 			if (args[i + 1] && !is_redirect_or_pipe(args[i + 1]))

--- a/sources/parser/parser4.c
+++ b/sources/parser/parser4.c
@@ -1,85 +1,82 @@
 #include "../includes/minishell.h"
 
-void    parser_unset(t_token **token, char **args)
+void parser_unset(t_token **token, char **args)
 {
     int i;
 
+    add_token(token, "unset", NULL);
     i = 1;
     while (args[i])
     {
         if (is_valid_varname(args[i]))
-            add_token(token, args[i], NULL);
+            add_token(token, NULL, args[i]);
         else
             printf("unset: '%s': not a valid identifier\n", args[i]);
         i++;
     }
 }
 
-void add_token(t_token **head, char *key, char *value)
+
+void add_token(t_token **head, char *type, char *value)
 {
 	t_token *new_token;
-	int key_len;
+	t_token *temp;
 
-	key_len = ft_strlen("export_") + ft_strlen(key) + 1;
 	new_token = malloc(sizeof(t_token));
 	if(!new_token)
 		return ;
-	new_token->type = malloc(key_len);
-	if(!new_token->type)
-	{	
-		return ;
-	}
-	ft_strcpy(new_token->type, "export_");
-	ft_strcat(new_token->type, key);
-	if (!value)
-		new_token->value = NULL;
+	if (type)
+		new_token->type = ft_strdup(type);
 	else
-		new_token->value = value;
-	new_token->next = *head;
-	*head = new_token;
+		new_token->type = NULL;
+	if (value)
+		new_token->value = ft_strdup(value);
+	else
+		new_token->value = NULL;
+	new_token->next = NULL;
+	if (*head == NULL)
+		*head = new_token;
+	else {
+		temp = *head;
+		while (temp->next)
+			temp = temp->next;
+		temp->next = new_token;
+	}
 }
 
 int	is_valid_varname(const char *str)
 {
 	int i;
 
-	i = 1;
 	if (!str || (!ft_isalpha(*str) && *str != '_'))
 		return 0;
+	i = 1;
 	while (str[i])
 	{
 		if (!ft_isalnum(str[i]) && str[i] != '_')
 			return 0;
+		i++;
 	}
 	return 1;
 }
 
-void	parser_export(t_token **head, char **args)
+void parser_export(t_token **head, char **args)
 {
-	int	i;
-	char	*eq;
-	
-	i = 1;
-	while (args[i])
-	{
-		eq = ft_strchr(args[i], '=');
-		if (eq)
-		{
-			*eq = '\0';
-			if(is_valid_varname(args[i]))
-				add_token(head, args[i], eq + 1);
-			else
-				printf("export: '%s': not valid identifier\n", args[i]);
+    int i;
+
+    add_token(head, "export", NULL);
+    i = 1;
+    while (args[i])
+    {
+        printf("export: checking '%s'\n", args[i]);
+		if (is_valid_var_or_assign(args[i])){
+            add_token(head, NULL, args[i]);
+			printf("export: '%s' added\n", args[i]);
 		}
-		else
-		{
-			if (is_valid_varname(args[i]))
-				add_token(head, args[i], NULL);
-			else
-				printf("export: '%s' :not a valid indentifier\n", args[i]);
-		}
-		i++;
-	}
+        else
+            printf("export: '%s': not a valid identifier\n", args[i]);
+        i++;
+    }
 }
 
 void	parser_cd(t_token **head, char **args, int i)

--- a/sources/parser/parser5.c
+++ b/sources/parser/parser5.c
@@ -40,11 +40,24 @@ void    parser_or(t_token **head)
     }
 }
 
-void    parser_env(t_token **token, char **args)
+void parser_env(t_token **head)
 {
-    if (args[1])
-        printf("env: too many arguments\n");
-    add_token(token, "env", NULL);
+    t_token *new_token = malloc(sizeof(t_token));
+    t_token *temp;
+    if (!new_token)
+        return;
+    new_token->type = ft_strdup("env");
+    new_token->value = NULL;
+    new_token->next = NULL;
+    if (*head == NULL)
+        *head = new_token;
+    else
+    {
+        temp = *head;
+        while (temp->next)
+            temp = temp->next;
+        temp->next = new_token;
+    }
 }
 
 void parser_exit(t_token **head)

--- a/sources/utils/utils_t_2.c
+++ b/sources/utils/utils_t_2.c
@@ -45,37 +45,56 @@ char	**conv_env_to_array(t_env *env)
 
 char **tokens_to_args(t_token *token)
 {
-    int count = 0;
-    t_token *tmp = token;
+	int 	count;
+	int 	i;
+	char	**args;
+	t_token	*tmp;
 
-    // Count: command + all value tokens (including value of first token)
-    while (tmp)
-    {
-        count++; // one for each token
-        tmp = tmp->next;
-    }
+	count = 0;
+	tmp = token;
+	while (tmp){
+		count++; // one for each token
+		tmp = tmp->next;
+	}
+	args = malloc(sizeof(char *) * (count + 1));
+	if (!args)
+		return NULL;
+	tmp = token;
+	i = 0;
+	args[i++] = ft_strdup(token->type);
+	if (token->value)
+		args[i++] = ft_strdup(token->value);
+	tmp = token->next;
+	while (tmp){
+		if (tmp->value)
+			args[i++] = ft_strdup(tmp->value);
+		tmp = tmp->next;
+	}
+	args[i] = NULL;
+	return args;
+}
+int	is_valid_var_or_assign(const char *str)
+{
+	char	*eq;
+	int		i;
 
-    char **args = malloc(sizeof(char *) * (count + 1));
-    if (!args)
-        return NULL;
-
-    tmp = token;
-    int i = 0;
-    // Always put command name
-    args[i++] = ft_strdup(token->type);
-
-    // If first token has a value, add it
-    if (token->value)
-        args[i++] = ft_strdup(token->value);
-
-    // Add values of all subsequent tokens
-    tmp = token->next;
-    while (tmp)
-    {
-        if (tmp->value)
-            args[i++] = ft_strdup(tmp->value);
-        tmp = tmp->next;
-    }
-    args[i] = NULL;
-    return args;
+	if(!str)
+		return (0);
+	eq = ft_strchr(str, '=');
+	if (eq){
+		if (eq == str)
+			return (0);
+		i = 0;
+		while (&str[i] < eq)
+		{
+		if (i ==0 && !ft_isalpha(str[i]) && str[i] != '_')
+			return (0);
+		if (!ft_isalnum(str[i]) && str[i] != '_')
+			return (0);
+		i++;
+		}
+		return (1);
+	}
+	else
+		return (is_valid_varname(str));
 }

--- a/tests/tests_handler.c
+++ b/tests/tests_handler.c
@@ -457,7 +457,7 @@ void ft_test_unset(t_minishell *shell)
     cmd.args = args2;
     
     printf("\nTesting unset builtin: %s %s\n", cmd.args[0], cmd.args[1]);
-    ft_unset(&(shell->env_list), cmd.args[1]); 
+    ft_unset(&(shell->env_list), cmd.args); 
 
     // Verify the variable was unset
     printf("\nVerifying UNSET_TEST is unset:\n");


### PR DESCRIPTION
Sporo kodu przerobionego zeby uruchomic export, unset i env.
Z tym cholernym exportem sie tyle meczylem a powodem byl brak inkrementacji i w jednej petli.
Ale juz wszystko wreszcie chyba dziala
Ustawilem tez warunek na wyjscie z glownej petli minichell_loop na shell->running (bylo 1). To pomoze przy walce z leakami.